### PR TITLE
update Rocket Barrage overclock

### DIFF
--- a/guids.json
+++ b/guids.json
@@ -1402,7 +1402,7 @@
     "8E6816C3DAEE2C49B93E8FA67CF13B1A": {
         "class": "Gunner",
         "weapon": "'Hurricane' Guided Rocket System",
-        "name": "Manual Guidance Cutoff",
+        "name": "Rocket Barrage",
         "cost": {
             "credits": 7050,
             "bismor": 75,


### PR DESCRIPTION
remove the "Manual Guidance Cutoff"  and add the "Rocket Barrage" Weapon Overclock of 'Hurricane' Guided Rocket System(Gunner) Based on in-game updates.