### PR TITLE
Handled runtime error when no file is selected

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -209,6 +209,9 @@ def open_file() -> None:
     )[0]
     # print('about to open file')
 
+    if not file_name:
+        return
+
     widget.setWindowTitle(f"DRG Save Editor - {file_name}")  # window-dressing
     with open(file_name, "rb") as f:
         save_data = f.read()


### PR DESCRIPTION
Small fix to avoid unnecessary runtime exceptions whenever a file is not selected.