### PR TITLE
fix(issue #79): potential UnicodeDecodeError When Initiating the Program

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -1465,7 +1465,7 @@ if __name__ == "__main__":
     app = QApplication()
 
     # load reference data
-    with open("guids.json", "r") as g:
+    with open("guids.json", "r", encoding="utf-8") as g:
         guid_dict: dict[str, Any] = json.loads(g.read())
 
     try:


### PR DESCRIPTION
If the users language / local would make the default encoding for python something other than utf-8, the program will crash when loading the guids.json file.
This fixes that issue by explicitly setting the encoding.

fixes #79