### PR TITLE
build: use console mode and build as standalone exe 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run PyInstaller
         run: |
-          pyinstaller --name=DRG-Save-Editor --console --noconfirm src/main/python/main.py
+          pyinstaller --name=DRG-Save-Editor --console --onefile --noconfirm src/main/python/main.py --add-data "editor.ui;." --add-data "guids.json;."
 
       - name: Copy required files
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run PyInstaller
         run: |
-          pyinstaller --name=DRG-Save-Editor --console --noconfirm src/main/python/main.py
+          pyinstaller --name=DRG-Save-Editor --console --onefile --noconfirm src/main/python/main.py --add-data "editor.ui:." --add-data "guids.json:."
 
       - name: Copy required files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run PyInstaller
         run: |
-          pyinstaller --name=DRG-Save-Editor --windowed --noconfirm src/main/python/main.py
+          pyinstaller --name=DRG-Save-Editor --console --noconfirm src/main/python/main.py
 
       - name: Copy required files
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run PyInstaller
         run: |
-          pyinstaller --name=DRG-Save-Editor --windowed --noconfirm src/main/python/main.py
+          pyinstaller --name=DRG-Save-Editor --console --noconfirm src/main/python/main.py
 
       - name: Copy required files
         run: |

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -1,4 +1,5 @@
 import json
+import os
 import struct
 import sys
 from copy import deepcopy
@@ -216,6 +217,11 @@ class EditorUI:
     def __init__(self):
         # specify and open the UI
         ui_file_name = "editor.ui"
+
+        # check if the UI file exists in the current working directory, if not, check the directory of the script (for PyInstaller)
+        if not os.path.exists(ui_file_name):
+            ui_file_name = os.path.join(os.path.dirname(__file__), ui_file_name)
+
         ui_file = QFile(ui_file_name)
         if not ui_file.open(QIODevice.ReadOnly):  # type: ignore
             print("Cannot open {}: {}".format(ui_file_name, ui_file.errorString()))
@@ -1469,10 +1475,17 @@ season_selected: int = LATEST_SEASON
 if __name__ == "__main__":
     QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts, True)
     # print(os.getcwd())
+    # print(os.path.dirname(__file__))
     app = QApplication()
 
+    guids_file = "guids.json"
+
+    # check if the guid file exists in the current working directory, if not, use the one in the same directory as the script (for pyinstaller)
+    if not os.path.exists(guids_file):
+        guids_file = os.path.join(os.path.dirname(__file__), guids_file)
+
     # load reference data
-    with open("guids.json", "r", encoding="utf-8") as g:
+    with open(guids_file, "r", encoding="utf-8") as g:
         guid_dict: dict[str, Any] = json.loads(g.read())
 
     try:


### PR DESCRIPTION
It's not always clear to users that the executable is intended to be run from the terminal, this change removes the --windowed flag from the build workflow so this if users start the executable from, say, an app launcher or file explorer, a console will be spawned and the gui will be attached to it.

Additionally, we now build the executable as a single standalone binary, that unpacks it's required files into a temp directory (this was done with the --onefile flag)